### PR TITLE
Changed x_test_hr to x_test_lr

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -217,7 +217,7 @@ def plot_test_generated_images_for_model(output_dir, generator, x_test_hr, x_tes
 def plot_test_generated_images(output_dir, generator, x_test_lr, figsize=(5, 5)):
     
     examples = x_test_lr.shape[0]
-    image_batch_hr = denormalize(x_test_hr)
+    image_batch_lr = denormalize(x_test_lr)
     gen_img = generator.predict(image_batch_lr)
     generated_image = denormalize(gen_img)
     


### PR DESCRIPTION
Fix for this error while testing model:
```Traceback (most recent call last):
  File "Keras-SRGAN/test.py", line 67, in <module>
    test_model_for_lr_images(values.input_low_res, model, values.number_of_images, values.output_dir)
  File "Keras-SRGAN/test.py", line 34, in test_model_for_lr_images
    Utils.plot_test_generated_images(output_dir, model, x_test_lr)
  File "/content/Keras-SRGAN/Utils.py", line 220, in plot_test_generated_images
    image_batch_hr = denormalize(x_test_hr)
NameError: name 'x_test_hr' is not defined```